### PR TITLE
ci: Add gradle build workflow to CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,23 @@
+name: Java CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Build with gradle
+      run: gradle build
+


### PR DESCRIPTION
Let's make sure the tree stays green. Adapted from:

https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle

Closes #19

Signed-off-by: Alyssa Rosenzweig <a.rosenzweig@mail.utoronto.ca>